### PR TITLE
Remove tests/phan from PHPCS exclusions

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -154,7 +154,6 @@
 		<exclude-pattern>*/languages/*\.php</exclude-pattern>
 		<!-- Skip violations in some tests for now -->
 		<exclude-pattern>*/tests/parser/*\.php</exclude-pattern>
-		<exclude-pattern>*/tests/phan/*\.php</exclude-pattern>
 		<exclude-pattern>*/tests/phpunit/maintenance/*\.php</exclude-pattern>
 		<exclude-pattern>*/tests/phpunit/bootstrap\.php</exclude-pattern>
 		<exclude-pattern>*/tests/phpunit/phpunit\.php</exclude-pattern>


### PR DESCRIPTION
This repo doesn't run phan. Also, the config isn't in tests/phan anymore.